### PR TITLE
Added libxml2 to dependency list and fixed formatting of Neon

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -11,10 +11,13 @@ Dependencies
 Before you start, make sure you have installed following libraries:
 
  * Neon -- HTTP client library
-   http://www.webdav.org/neon/
+ 	 http://www.webdav.org/neon/
 
  * Jansson -- C library for working with JSON data
  	 http://www.digip.org/jansson/
+
+* Libxml2 -- C library for parsing XML
+ 	 http://xmlsoft.org/
 
 Building
 ========


### PR DESCRIPTION
libxml2 was a dependency, but wasn't listed.