### PR TITLE
Add HTTPS support

### DIFF
--- a/src/CoverArt.cc
+++ b/src/CoverArt.cc
@@ -93,7 +93,7 @@ void CoverArtArchive::CCoverArt::SetProxyPassword(const std::string& ProxyPasswo
 std::vector<unsigned char> CoverArtArchive::CCoverArt::FetchFront(const std::string& ReleaseID) const
 {
 	std::stringstream URL;
-	URL << "http://coverartarchive.org/release/" << ReleaseID << "/front";
+	URL << "https://coverartarchive.org/release/" << ReleaseID << "/front";
 
 	return MakeRequest(URL.str());
 }
@@ -101,7 +101,7 @@ std::vector<unsigned char> CoverArtArchive::CCoverArt::FetchFront(const std::str
 std::vector<unsigned char> CoverArtArchive::CCoverArt::FetchBack(const std::string& ReleaseID) const
 {
 	std::stringstream URL;
-	URL << "http://coverartarchive.org/release/" << ReleaseID << "/back";
+	URL << "https://coverartarchive.org/release/" << ReleaseID << "/back";
 
 	return MakeRequest(URL.str());
 }
@@ -109,7 +109,7 @@ std::vector<unsigned char> CoverArtArchive::CCoverArt::FetchBack(const std::stri
 std::vector<unsigned char> CoverArtArchive::CCoverArt::FetchImage(const std::string& ReleaseID, const std::string& ID, tImageSize Size) const
 {
 	std::stringstream URL;
-	URL << "http://coverartarchive.org/release/" << ReleaseID << "/" << ID;
+	URL << "https://coverartarchive.org/release/" << ReleaseID << "/" << ID;
 
 	switch (Size)
 	{
@@ -206,7 +206,7 @@ CoverArtArchive::CReleaseInfo CoverArtArchive::CCoverArt::ReleaseInfo(const std:
 	CReleaseInfo ReleaseInfo;
 
 	std::stringstream URL;
-	URL << "http://coverartarchive.org/release/" << ReleaseID;
+	URL << "https://coverartarchive.org/release/" << ReleaseID;
 
 	std::vector<unsigned char> JSON=MakeRequest(URL.str());
 	std::string strJSON(JSON.begin(),JSON.end());

--- a/src/NeonWrappers.h
+++ b/src/NeonWrappers.h
@@ -50,6 +50,7 @@ class CNESessionWrapper
 		CNESessionWrapper(const std::string& Scheme, const std::string& Host, int Port)
 		:	m_Session(ne_session_create(Scheme.c_str(), Host.c_str(), Port))
 		{
+			ne_ssl_trust_default_ca(m_Session);
 		}
 
 		~CNESessionWrapper()


### PR DESCRIPTION
See https://tickets.metabrainz.org/browse/MBH-444 - caa.org is at some point going to move to HTTPS. Without calling `ne_ssl_trust_default_ca`, connections to caa.org fail because the certificate issuer is not trusted.

This also changes all hardcoded URLs to https - I'm not sure how useful that is, given that no personal information is sent along here, but it helps skipping the eventual redirect.

Fixes https://tickets.metabrainz.org/browse/LCA-6