### PR TITLE
Use const& when catching exceptions

### DIFF
--- a/examples/example.cc
+++ b/examples/example.cc
@@ -60,7 +60,7 @@ int main(int argc, const char *argv[])
 			}
 		}
 
-		catch (CoverArtArchive::CExceptionBase e)
+		catch (const CoverArtArchive::CExceptionBase& e)
 		{
 			std::cout << "Exception: '" << e.what() << "'" << std::endl;
 		}
@@ -81,7 +81,7 @@ int main(int argc, const char *argv[])
 			}
 		}
 
-		catch (CoverArtArchive::CExceptionBase e)
+		catch (const CoverArtArchive::CExceptionBase& e)
 		{
 			std::cout << "Exception: '" << e.what() << "'" << std::endl;
 		}
@@ -134,7 +134,7 @@ int main(int argc, const char *argv[])
 						Full.close();
 					}
 
-					catch (CoverArtArchive::CExceptionBase e)
+					catch (const CoverArtArchive::CExceptionBase& e)
 					{
 						std::cout << "Exception: '" << e.what() << "'" << std::endl;
 					}
@@ -158,7 +158,7 @@ int main(int argc, const char *argv[])
 								Large.close();
 							}
 
-							catch (CoverArtArchive::CExceptionBase e)
+							catch (const CoverArtArchive::CExceptionBase& e)
 							{
 								std::cout << "Exception: '" << e.what() << "'" << std::endl;
 							}
@@ -180,7 +180,7 @@ int main(int argc, const char *argv[])
 								Small.close();
 							}
 
-							catch (CoverArtArchive::CExceptionBase e)
+							catch (const CoverArtArchive::CExceptionBase& e)
 							{
 								std::cout << "Exception: '" << e.what() << "'" << std::endl;
 							}

--- a/src/HTTPFetch.cc
+++ b/src/HTTPFetch.cc
@@ -153,7 +153,7 @@ int CoverArtArchive::CHTTPFetch::Fetch(const std::string& URL, bool FollowRedire
 			Finished=true;
 		}
 
-		catch(CRedirect r)
+		catch(const CRedirect& r)
 		{
 			if (FollowRedirects)
 			{

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -27,7 +27,7 @@ int main(int /*argc*/, const char */*argv*/[])
 		std::cout << "Image has size " << Image.size() << std::endl;
 	}
 
-	catch (CoverArtArchive::CExceptionBase e)
+	catch (const CoverArtArchive::CExceptionBase& e)
 	{
 		std::cout << "Exception: " << e.what() << std::endl;
 	}


### PR DESCRIPTION
This fixes the following errors when building with GCC 8:
```
[  4%] Building CXX object src/CMakeFiles/coverartcc.dir/HTTPFetch.cc.o
/home/sebastian/development/libcoverart/src/HTTPFetch.cc: In member function ‘int CoverArtArchive::CHTTPFetch::Fetch(const string&, bool)’:
/home/sebastian/development/libcoverart/src/HTTPFetch.cc:156:19: error: catching polymorphic type ‘class CoverArtArchive::CRedirect’ by value [-Werror=catch-value=]
   catch(CRedirect r)
                   ^
cc1plus: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/coverartcc.dir/build.make:63: src/CMakeFiles/coverartcc.dir/HTTPFetch.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:187: src/CMakeFiles/coverartcc.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```